### PR TITLE
Fixed spelling on word 'preferred'

### DIFF
--- a/Sleek theme-dark/sleek/theme.txt
+++ b/Sleek theme-dark/sleek/theme.txt
@@ -21,7 +21,7 @@ align = "center"
 }
 
 +label{
-text="select your prefered os"
+text="select your preferred os"
 font = "DejaVu Sans Regular 16"
 color="#8f8f8f"
 top=30%-60

--- a/Sleek theme-orange/sleek/theme.txt
+++ b/Sleek theme-orange/sleek/theme.txt
@@ -21,7 +21,7 @@ align = "center"
 }
 
 +label{
-text="select your prefered os"
+text="select your preferred os"
 font = "DejaVu Sans Regular 16"
 color="#777777"
 top=30%-60

--- a/Sleek theme-white/sleek/theme.txt
+++ b/Sleek theme-white/sleek/theme.txt
@@ -22,7 +22,7 @@ align = "center"
 }
 
 +label{
-text="select your prefered os"
+text="select your preferred os"
 font = "DejaVu Sans Regular 16"
 color="#8d8686"
 top=30%-60


### PR DESCRIPTION
I fixed the spelling on the word 'preferred' that displays on the grub theme welcome message.