### PR TITLE
fixed bigsur theme label not showing. fixes #21

### DIFF
--- a/Sleek theme-bigSur/sleek/theme.txt
+++ b/Sleek theme-bigSur/sleek/theme.txt
@@ -22,7 +22,7 @@ align = "center"
 
 +label{
 text="select your preferred os"
-font = "Poppins Refular 16"
+font = "Poppins Regular 16"
 color="#F3F3F3"
 top=30%-30
 left = 50%-80


### PR DESCRIPTION

fixes #21 
closes #21

- [x] fix typo in bigSur theme `theme.txt` file
<br>

fixed fontname of label in bigSur theme.txt file
```diff
- font = "Poppins Refular 16"
+ font = "Poppins Regular 16"
```
