### PR TITLE
Updated grub update command for fedora

### DIFF
--- a/Sleek theme-bigSur/install.sh
+++ b/Sleek theme-bigSur/install.sh
@@ -116,7 +116,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
     if has_command zypper; then
       grub2-mkconfig -o /boot/grub2/grub.cfg
     elif has_command dnf; then
-      grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+      grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
   fi
 

--- a/Sleek theme-dark/install.sh
+++ b/Sleek theme-dark/install.sh
@@ -116,7 +116,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
     if has_command zypper; then
       grub2-mkconfig -o /boot/grub2/grub.cfg
     elif has_command dnf; then
-      grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+      grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
   fi
 

--- a/Sleek theme-light/install.sh
+++ b/Sleek theme-light/install.sh
@@ -116,7 +116,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
     if has_command zypper; then
       grub2-mkconfig -o /boot/grub2/grub.cfg
     elif has_command dnf; then
-      grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+      grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
   fi
 

--- a/Sleek theme-orange/install.sh
+++ b/Sleek theme-orange/install.sh
@@ -116,7 +116,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
     if has_command zypper; then
       grub2-mkconfig -o /boot/grub2/grub.cfg
     elif has_command dnf; then
-      grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+      grub2-mkconfig -o /boot/grub2/grub.cfg
     fi
   fi
 


### PR DESCRIPTION
Newer versions of fedora use ```grub2-mkconfig -o /boot/grub2/grub.cfg``` to rebuild the grub config.

Reference : https://docs.fedoraproject.org/en-US/fedora/latest/system-administrators-guide/kernel-module-driver-configuration/Working_with_the_GRUB_2_Boot_Loader/

I updated the command in all 4 themes.