### PR TITLE
Fix comma placement in greeting message on GRUB interface

### DIFF
--- a/Sleek theme-bigSur/install.sh
+++ b/Sleek theme-bigSur/install.sh
@@ -85,7 +85,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
      fi
      prompt -i "\n Setting your username .......\n ."
    
-     sed -i "s/Grub Bootloader/Hello $username,/g"  $THEME_DIR/$THEME_NAME/theme.txt
+     sed -i "s/Grub Bootloader/Hello, $username/g"  $THEME_DIR/$THEME_NAME/theme.txt
   fi
   
   

--- a/Sleek theme-dark/install.sh
+++ b/Sleek theme-dark/install.sh
@@ -85,7 +85,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
      fi
      prompt -i "\n Setting your username .......\n ."
    
-     sed -i "s/Grub Bootloader/Hello $username,/g"  $THEME_DIR/$THEME_NAME/theme.txt
+     sed -i "s/Grub Bootloader/Hello, $username/g"  $THEME_DIR/$THEME_NAME/theme.txt
   fi
   
   

--- a/Sleek theme-light/install.sh
+++ b/Sleek theme-light/install.sh
@@ -85,7 +85,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
      fi
      prompt -i "\n Setting your username .......\n ."
    
-     sed -i "s/Grub Bootloader/Hello $username,/g"  $THEME_DIR/$THEME_NAME/theme.txt
+     sed -i "s/Grub Bootloader/Hello, $username/g"  $THEME_DIR/$THEME_NAME/theme.txt
   fi
   
   

--- a/Sleek theme-orange/install.sh
+++ b/Sleek theme-orange/install.sh
@@ -85,7 +85,7 @@ if [ "$UID" -eq "$ROOT_UID" ]; then
      fi
      prompt -i "\n Setting your username .......\n ."
    
-     sed -i "s/Grub Bootloader/Hello $username,/g"  $THEME_DIR/$THEME_NAME/theme.txt
+     sed -i "s/Grub Bootloader/Hello, $username/g"  $THEME_DIR/$THEME_NAME/theme.txt
   fi
   
   


### PR DESCRIPTION
Before:
`Hello $username,`

After:
`Hello, $username`

This fixes the placement of the comma in the GRUB interface greeting message. Previously, the comma appeared after the username, which is grammatically incorrect. It now correctly appears before the username.

